### PR TITLE
Ann_breakdown v2 using children_; fixed children_ for cudagraph events

### DIFF
--- a/pipit/readers/nsight_sqlite_reader.py
+++ b/pipit/readers/nsight_sqlite_reader.py
@@ -291,10 +291,16 @@ class NSightSQLiteReader:
         # Convert to numpy otherwise the index messes stuff up
         # TODO: can get rid of the apply if we use an Arrow ListDtype for children
         # globally
-        children = calls_that_launch["index_y"].apply(lambda x: [x])
-        trace_df.loc[calls_that_launch["index_x"].to_numpy(), "_children"] = (
-            children.to_numpy()
+
+        # index_x can appear multiple times in calls_that_launch and we need to add all the index_y values to the _children list
+        # 1) Group by index_x → collect all index_y into a Python list
+        child_map = (
+            calls_that_launch
+              .groupby("index_x")["index_y"]
+              .apply(list)
         )
+        trace_df.loc[child_map.index, "_children"] = child_map.to_numpy()
+
         trace_df.loc[calls_that_launch["index_y"].to_numpy(), "_parent"] = (
             calls_that_launch["index_x"].to_numpy()
         )

--- a/pipit/readers/nsight_sqlite_reader.py
+++ b/pipit/readers/nsight_sqlite_reader.py
@@ -68,64 +68,64 @@ class NSightSQLiteReader:
         JOIN CUPTI_ACTIVITY_KIND_RUNTIME as cuda_api
             ON cuda_gpu.correlationId = cuda_api.correlationId
         """,
-            # TODO: reading these events are disabled for now since
-            # nothing uses them ATM. Please remove if they have been
-            # commented out like this for a while.
-            #     """
-            # SELECT
-            #     cuda_memcpy.start as Enter,
-            #     cuda_memcpy.end as Leave,
-            #     cuda_memcpy.deviceId as gpuId,
-            #     memcpy_labels.name as Name,
-            #     cuda_memcpy.streamId,
-            #     'cuda_memcpy' as type,
-            #     bytes,
-            #     cuda_memcpy.correlationId as id,
-            #     (cuda_api.globalTid >> 24) & 0x00FFFFFF AS "Process",
-            #     null as meta
-            # FROM CUPTI_ACTIVITY_KIND_MEMCPY as cuda_memcpy
-            # JOIN ENUM_CUDA_MEMCPY_OPER as memcpy_labels
-            #     ON cuda_memcpy.copyKind = memcpy_labels.id
-            # JOIN CUPTI_ACTIVITY_KIND_RUNTIME as cuda_api
-            #     ON cuda_memcpy.correlationId = cuda_api.correlationId
-            # """,
-            #     """
-            # SELECT
-            #     cuda_memset.start as Enter,
-            #     cuda_memset.end as Leave,
-            #     cuda_memset.deviceId as gpuId,
-            #     memset_labels.name as Name,
-            #     streamId,
-            #     'cuda_memset' as type,
-            #     bytes,
-            #     cuda_memset.correlationId as id,
-            #     (cuda_api.globalTid >> 24) & 0x00FFFFFF AS "Process",
-            #     null as meta
-            # FROM CUPTI_ACTIVITY_KIND_MEMSET as cuda_memset
-            # JOIN ENUM_CUDA_MEM_KIND as memset_labels
-            #     ON cuda_memset.memKind = memset_labels.id
-            # JOIN CUPTI_ACTIVITY_KIND_RUNTIME as cuda_api
-            #     ON cuda_memset.correlationId = cuda_api.correlationId
-            # """,
-            #     """
-            # SELECT
-            #     cuda_sync.start as Enter,
-            #     cuda_sync.end as Leave,
-            #     cuda_sync.deviceId as gpuId,
-            #     sync_labels.name as Name,
-            #     cuda_sync.streamId,
-            #     'cuda_sync' as type,
-            #     null as bytes,
-            #     cuda_sync.correlationId as id,
-            #     (cuda_api.globalTid >> 24) & 0x00FFFFFF AS "Process",
-            #     null as meta
-            # FROM CUPTI_ACTIVITY_KIND_SYNCHRONIZATION as cuda_sync
-            # JOIN ENUM_CUPTI_SYNC_TYPE as sync_labels
-            #     ON cuda_sync.syncType = sync_labels.id
-            # JOIN CUPTI_ACTIVITY_KIND_RUNTIME as cuda_api
-            #     ON cuda_sync.correlationId = cuda_api.correlationId
-            # """,
-            """
+        # TODO: reading these events are disabled for now since
+        # nothing uses them ATM. Please remove if they have been
+        # commented out like this for a while.
+        """
+        SELECT
+            cuda_memcpy.start as Enter,
+            cuda_memcpy.end as Leave,
+            cuda_memcpy.deviceId as gpuId,
+            memcpy_labels.name as Name,
+            cuda_memcpy.streamId,
+            'cuda_memcpy' as type,
+            bytes,
+            cuda_memcpy.correlationId as id,
+            (cuda_api.globalTid >> 24) & 0x00FFFFFF AS "Process",
+            null as meta
+        FROM CUPTI_ACTIVITY_KIND_MEMCPY as cuda_memcpy
+        JOIN ENUM_CUDA_MEMCPY_OPER as memcpy_labels
+            ON cuda_memcpy.copyKind = memcpy_labels.id
+        JOIN CUPTI_ACTIVITY_KIND_RUNTIME as cuda_api
+            ON cuda_memcpy.correlationId = cuda_api.correlationId
+        """,
+        """
+        SELECT
+            cuda_memset.start as Enter,
+            cuda_memset.end as Leave,
+            cuda_memset.deviceId as gpuId,
+            memset_labels.name as Name,
+            streamId,
+            'cuda_memset' as type,
+            bytes,
+            cuda_memset.correlationId as id,
+            (cuda_api.globalTid >> 24) & 0x00FFFFFF AS "Process",
+            null as meta
+        FROM CUPTI_ACTIVITY_KIND_MEMSET as cuda_memset
+        JOIN ENUM_CUDA_MEM_KIND as memset_labels
+            ON cuda_memset.memKind = memset_labels.id
+        JOIN CUPTI_ACTIVITY_KIND_RUNTIME as cuda_api
+            ON cuda_memset.correlationId = cuda_api.correlationId
+        """,
+        """
+        SELECT
+            cuda_sync.start as Enter,
+            cuda_sync.end as Leave,
+            cuda_sync.deviceId as gpuId,
+            sync_labels.name as Name,
+            cuda_sync.streamId,
+            'cuda_sync' as type,
+            null as bytes,
+            cuda_sync.correlationId as id,
+            (cuda_api.globalTid >> 24) & 0x00FFFFFF AS "Process",
+            null as meta
+        FROM CUPTI_ACTIVITY_KIND_SYNCHRONIZATION as cuda_sync
+        JOIN ENUM_CUPTI_SYNC_TYPE as sync_labels
+            ON cuda_sync.syncType = sync_labels.id
+        JOIN CUPTI_ACTIVITY_KIND_RUNTIME as cuda_api
+            ON cuda_sync.correlationId = cuda_api.correlationId
+        """,
+        """
         SELECT
             cuda_graph.start as Enter,
             cuda_graph.end as Leave,
@@ -193,9 +193,9 @@ class NSightSQLiteReader:
             gpu_trace_needed_tbls = [
                 "CUPTI_ACTIVITY_KIND_RUNTIME",
                 # TODO: remove if we decide we don't need these events
-                # "CUPTI_ACTIVITY_KIND_MEMCPY",
-                # CUPTI_ACTIVITY_KIND_MEMSET",
-                # "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION",
+                "CUPTI_ACTIVITY_KIND_MEMCPY",
+                "CUPTI_ACTIVITY_KIND_MEMSET",
+                "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION",
                 "CUPTI_ACTIVITY_KIND_GRAPH_TRACE",
             ]
 

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -1103,6 +1103,7 @@ class Trace:
         
         breakdown_columns = {
             "gpu_time": 0,
+            "mem_time": 0,
             "gpu_idle_time": 0,
         }
 
@@ -1164,7 +1165,7 @@ class Trace:
                 ts = child_row["Timestamp (ns)"]
                 mts = child_row["_matching_timestamp"]
 
-                if not pd.isna(child_type) and child_type in ("kernel", "comm"):
+                if not pd.isna(child_type) and child_type in ("kernel", "cuda_memcpy"):
                     if not pd.isna(ts):
                         all_timestamps.append(ts)
                     if not pd.isna(mts):
@@ -1180,10 +1181,14 @@ class Trace:
 
                 # If this row is a kernel or comm, accumulate its active GPU time
                 if not pd.isna(child_row["type"]):
-                    if child_row["type"] in ("kernel", "comm"):
+                    if child_row["type"] in ("kernel", "cuda_memcpy"):
                         if (not pd.isna(ts)) and (not pd.isna(mts)):
-                            breakdown["gpu_time"] += abs(mts - ts)
-                            active_gpu_time += abs(mts - ts)
+                            if child_row["type"] == "kernel":
+                                breakdown["gpu_time"] += abs(mts - ts)
+                                active_gpu_time += abs(mts - ts)
+                            else:
+                                breakdown["mem_time"] += abs(mts - ts)
+                                active_gpu_time += abs(mts - ts)
 
                             if mapper is not None:
                                 # Match the name with the mapper key regex

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -5,6 +5,8 @@
 
 import numpy as np
 import pandas as pd
+import copy
+import re
 
 from pipit.util.cct import create_cct
 
@@ -1058,11 +1060,21 @@ class Trace:
 
         return total_time
     
-    def ann_time_breakdown_v2(self, filter_regex=None):
+    def ann_time_breakdown_v2(self, 
+                              filter_regex=None, 
+                              mapper=None,
+                              ):
         """
         Time breakdown by NVTX-annotation, using the `_children` pointers.
 
         Now supports repeated annotation names by indexing results with each annotation's row-index.
+        Parameters
+        ----------
+        filter_regex: str, list, optional
+            A regex string or list of regexes to select specific annotations
+            to include in the breakdown.
+        mapper: dict, optional
+            A dictionary mapping kernel names to their corresponding groups
         Returns a DataFrame with:
            - index  = annotation row-index (ann_idx)
            - columns: ["Name", "gpu_time", "gpu_idle_time"]
@@ -1088,6 +1100,17 @@ class Trace:
             else:
                 filter_pattern = filter_regex
             ann_events = ann_events[ann_events["Name"].str.contains(filter_pattern, regex=True)]
+        
+        breakdown_columns = {
+            "gpu_time": 0,
+            "gpu_idle_time": 0,
+        }
+
+        # Based on the mapper, get the different time columns we need to compute
+        if mapper is not None:
+            for key, value in mapper.items():
+                if value not in breakdown_columns:
+                    breakdown_columns[value] = 0
 
         # Prepare a list for per-annotation records
         records = []
@@ -1105,9 +1128,7 @@ class Trace:
                     "ann_idx": ann_idx,
                     "Name": ann_name,
                     "cpu_time": cpu_time,
-                    "gpu_time": 0,
-                    "comm_time": 0,
-                    "gpu_idle_time": 0,
+                    **breakdown_columns,
                 })
                 continue
 
@@ -1124,7 +1145,7 @@ class Trace:
             all_timestamps = []
             all_matching = []
             active_gpu_time = 0
-            comm_time = 0
+            breakdown = copy.deepcopy(breakdown_columns)
 
             # Depth‐first traversal of all descendants
             while child_stack:
@@ -1161,10 +1182,16 @@ class Trace:
                 if not pd.isna(child_row["type"]):
                     if child_row["type"] in ("kernel", "comm"):
                         if (not pd.isna(ts)) and (not pd.isna(mts)):
+                            breakdown["gpu_time"] += abs(mts - ts)
                             active_gpu_time += abs(mts - ts)
 
-                            if child_row["type"] == "comm":
-                                comm_time += abs(mts - ts)
+                            if mapper is not None:
+                                # Match the name with the mapper key regex
+                                for key, value in mapper.items():
+                                    label = child_row["Name"]
+                                    if re.search(key, label):
+                                        breakdown[value] += abs(mts - ts)
+                                        break
                     
 
             # 4) Compute overall [min, max] window, then idle time
@@ -1173,6 +1200,7 @@ class Trace:
                 overall_max = max(all_timestamps + all_matching)
                 idle_gpu_time = (overall_max - overall_min) - active_gpu_time
                 idle_gpu_time = max(idle_gpu_time, 0)  # clamp ≥ 0
+                breakdown["gpu_idle_time"] += idle_gpu_time
             else:
                 idle_gpu_time = 0
 
@@ -1180,15 +1208,14 @@ class Trace:
                 "ann_idx": ann_idx,
                 "Name": ann_name,
                 "cpu_time": cpu_time,
-                "gpu_time": active_gpu_time,
-                "comm_time": comm_time,
-                "gpu_idle_time": idle_gpu_time,
+                **breakdown,
             })
 
+        
         # 5) Build DataFrame, indexed by ann_idx (annotation row-index)
         result_df = (
             pd.DataFrame(records)
-              .set_index("ann_idx")[["Name", "cpu_time", "gpu_time", "comm_time", "gpu_idle_time"]]
+              .set_index("ann_idx")[["Name", "cpu_time"] + list(breakdown_columns.keys())]
         )
         return result_df
 

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -1057,6 +1057,140 @@ class Trace:
         total_time = ann_time
 
         return total_time
+    
+    def ann_time_breakdown_v2(self, filter_regex=None):
+        """
+        Time breakdown by NVTX-annotation, using the `_children` pointers.
+
+        Now supports repeated annotation names by indexing results with each annotation's row-index.
+        Returns a DataFrame with:
+           - index  = annotation row-index (ann_idx)
+           - columns: ["Name", "gpu_time", "gpu_idle_time"]
+        """
+        # calculate inclusive metrics
+        if "time.inc" not in self.events.columns:
+            self.calc_inc_metrics(["Timestamp (ns)"])
+
+        # calculate exclusive time if needed
+        if "time.exc" not in self.events.columns:
+            self.calc_exc_metrics(["Timestamp (ns)"])
+
+        # 1) Select all "Enter" events of type "annotation"
+        ann_events = self.events[
+            (self.events["type"] == "annotation") &
+            (self.events["Event Type"] == "Enter")
+        ]
+
+        # 2) Optionally filter by regex on the annotation Name
+        if filter_regex is not None:
+            if isinstance(filter_regex, list):
+                filter_pattern = "|".join(filter_regex)
+            else:
+                filter_pattern = filter_regex
+            ann_events = ann_events[ann_events["Name"].str.contains(filter_pattern, regex=True)]
+
+        # Prepare a list for per-annotation records
+        records = []
+
+        # 3) For each annotation row (by index), walk its descendants
+        for ann_idx, ann_row in ann_events.iterrows():
+            ann_name = ann_row["Name"]
+            raw_children = ann_row["_children"]
+            cpu_time = ann_row["time.inc"]
+
+            # If _children is NaN, record zeros immediately
+            is_list_like = isinstance(raw_children, (list, tuple, np.ndarray))
+            if (not is_list_like) and pd.isna(raw_children):
+                records.append({
+                    "ann_idx": ann_idx,
+                    "Name": ann_name,
+                    "cpu_time": cpu_time,
+                    "gpu_time": 0,
+                    "comm_time": 0,
+                    "gpu_idle_time": 0,
+                })
+                continue
+
+              
+            # Normalize raw_children into a list of ints
+            if isinstance(raw_children, (int, np.integer)):
+                child_stack = [int(raw_children)]
+            else:
+                # Assume it's already a Python list of ints
+                child_stack = list(raw_children)
+
+
+            visited = set()
+            all_timestamps = []
+            all_matching = []
+            active_gpu_time = 0
+            comm_time = 0
+
+            # Depth‐first traversal of all descendants
+            while child_stack:
+                cid = child_stack.pop()
+                if cid in visited:
+                    continue
+                if cid not in self.events.index:
+                    # Skip invalid indices
+                    continue
+                  
+                visited.add(cid)
+                child_row = self.events.loc[cid]
+                child_type = child_row["type"]
+
+                # Record this row's timestamps (if present)
+                ts = child_row["Timestamp (ns)"]
+                mts = child_row["_matching_timestamp"]
+
+                if not pd.isna(child_type) and child_type in ("kernel", "comm"):
+                    if not pd.isna(ts):
+                        all_timestamps.append(ts)
+                    if not pd.isna(mts):
+                        all_matching.append(mts)
+
+                # If this row has its own children, push them too
+                child_children = child_row["_children"]
+                if isinstance(child_children, (list, tuple, np.ndarray, int, np.integer)):
+                    if isinstance(child_children, (int, np.integer)):
+                        child_stack.append(int(child_children))
+                    else:
+                        child_stack.extend(list(child_children))
+
+                # If this row is a kernel or comm, accumulate its active GPU time
+                if not pd.isna(child_row["type"]):
+                    if child_row["type"] in ("kernel", "comm"):
+                        if (not pd.isna(ts)) and (not pd.isna(mts)):
+                            active_gpu_time += abs(mts - ts)
+
+                            if child_row["type"] == "comm":
+                                comm_time += abs(mts - ts)
+                    
+
+            # 4) Compute overall [min, max] window, then idle time
+            if all_timestamps or all_matching:
+                overall_min = min(all_timestamps + all_matching)
+                overall_max = max(all_timestamps + all_matching)
+                idle_gpu_time = (overall_max - overall_min) - active_gpu_time
+                idle_gpu_time = max(idle_gpu_time, 0)  # clamp ≥ 0
+            else:
+                idle_gpu_time = 0
+
+            records.append({
+                "ann_idx": ann_idx,
+                "Name": ann_name,
+                "cpu_time": cpu_time,
+                "gpu_time": active_gpu_time,
+                "comm_time": comm_time,
+                "gpu_idle_time": idle_gpu_time,
+            })
+
+        # 5) Build DataFrame, indexed by ann_idx (annotation row-index)
+        result_df = (
+            pd.DataFrame(records)
+              .set_index("ann_idx")[["Name", "cpu_time", "gpu_time", "comm_time", "gpu_idle_time"]]
+        )
+        return result_df
 
     def filter_by_label(self, label_name, filter_range=None):
         """


### PR DESCRIPTION
Fix: Cudagraph children include all children
Added: ann_breakdown_v2 that uses DFS to get per-annotation GPU, idle, CPU and comm time

ann_breakdown and ann_breakdown_v2 have matching results in gpu_time and cpu_time but idle time is fixed in ann_breakdwon_v2 